### PR TITLE
change reinforcements shamans to have correct colosim npc id

### DIFF
--- a/src/main/java/com/duckblade/osrs/fortis/features/loslinks/LosLinks.java
+++ b/src/main/java/com/duckblade/osrs/fortis/features/loslinks/LosLinks.java
@@ -317,6 +317,7 @@ public class LosLinks implements PluginLifecycleComponent
 			npc.getIndex(),
 			convertToLoSCoordinates(LocalPoint.fromWorld(npc.getWorldView(), npc.getWorldLocation())),
 			NPC_ID_TO_ENEMY_TYPE.get(npc.getId()),
+			reinforcementNpcs.contains(npc.getIndex()),
 			orbData,
 			orbData != null && orbData.getThird() != null
 		);

--- a/src/main/java/com/duckblade/osrs/fortis/features/loslinks/model/NpcSpawn.java
+++ b/src/main/java/com/duckblade/osrs/fortis/features/loslinks/model/NpcSpawn.java
@@ -10,6 +10,7 @@ public class NpcSpawn
 	private final int npcIndex;
 	private final Point swTile; // in colosim coords
 	private final Enemy enemyType;
+	private final boolean reinforcement;
 	private final ManticoreOrbOrder orbOrder;
 	private final boolean manticoreCharged;
 
@@ -20,7 +21,7 @@ public class NpcSpawn
 			"%02d%02d%d",
 			swTile.getX(),
 			swTile.getY(),
-			enemyType.getColosimLosId()
+			enemyType.getColosimLosId(reinforcement)
 		));
 
 		if (enemyType == Enemy.MANTICORE)

--- a/src/main/java/com/duckblade/osrs/fortis/util/spawns/Enemy.java
+++ b/src/main/java/com/duckblade/osrs/fortis/util/spawns/Enemy.java
@@ -8,20 +8,26 @@ import lombok.RequiredArgsConstructor;
 public enum Enemy
 {
 
-	FREMENNIK("Fremennik", "Fremmy", -1),
-	SERPENT_SHAMAN("Serpent Shaman", "Mage", 1),
-	JAGUAR_WARRIOR("Jaguar Warrior", "Melee", 3),
-	JAVELIN_COLOSSUS("Javelin Colossus", "Ranger", 2),
-	MANTICORE("Manticore", "Lion", 4),
-	SHOCKWAVE_COLOSSUS("Shockwave Colossus", "Shocker", 6),
-	MINOTAUR("Minotaur", "Minotaur", 5),
-	SOL_HEREDIT("Sol Heredit", "Sol Heredit", -1),
+	FREMENNIK("Fremennik", "Fremmy", -1, -1),
+	SERPENT_SHAMAN("Serpent Shaman", "Mage", 1, 7),
+	JAGUAR_WARRIOR("Jaguar Warrior", "Melee", 3, -1),
+	JAVELIN_COLOSSUS("Javelin Colossus", "Ranger", 2, -1),
+	MANTICORE("Manticore", "Lion", 4, -1),
+	SHOCKWAVE_COLOSSUS("Shockwave Colossus", "Shocker", 6, -1),
+	MINOTAUR("Minotaur", "Minotaur", 5, -1),
+	SOL_HEREDIT("Sol Heredit", "Sol Heredit", -1, -1),
 
-	ANGRY_BEES("Angry Bees", "BEES!!", -1),
+	ANGRY_BEES("Angry Bees", "BEES!!", -1, -1),
 	;
 
 	private final String npcName;
 	private final String colloquialName;
 	private final int colosimLosId;
+	private final int reinforcementColosimLosId;
+
+	public int getColosimLosId(boolean reinforcement)
+	{
+		return reinforcement && reinforcementColosimLosId != -1 ? reinforcementColosimLosId : colosimLosId;
+	}
 
 }


### PR DESCRIPTION
The Colosseum LOS tool was updated recently to account for the different "wiggle" mechanics that reinforcement serpent shamans exhibit compared to the serpent shamans that spawn at the start of the wave.

This PR sets the npc id's used in generating LOS links to the LOS tool to appropriately match the correct ID for serpent shamans depending on if they were spawned at the wave start or during reinforcements.