### PR TITLE
fixed wave 12 duplication in wave splits

### DIFF
--- a/src/main/java/com/duckblade/osrs/fortis/features/timetracking/SplitsTracker.java
+++ b/src/main/java/com/duckblade/osrs/fortis/features/timetracking/SplitsTracker.java
@@ -29,8 +29,6 @@ public class SplitsTracker implements PluginLifecycleComponent
 
 	private static final Pattern WAVE_COMPLETE_PATTERN =
 		Pattern.compile("Wave (?<wave>\\d+) completed! Wave duration:.*?(?<duration>[0-9]+:[.0-9]+).*");
-	private static final Pattern COLOSSEUM_COMPLETE_PATTERN =
-		Pattern.compile("Colosseum duration:.*?(?<duration>[0-9]+:[.0-9]+).*");
 
 	private final EventBus eventBus;
 
@@ -78,14 +76,13 @@ public class SplitsTracker implements PluginLifecycleComponent
 			return;
 		}
 
-		Matcher m;
-		if (!(m = WAVE_COMPLETE_PATTERN.matcher(msg)).matches() &&
-			!(m = COLOSSEUM_COMPLETE_PATTERN.matcher(msg)).matches())
+		Matcher m = WAVE_COMPLETE_PATTERN.matcher(msg);
+		if (!m.matches())
 		{
 			return;
 		}
 
-		int wave = m.groupCount() == 2 ? Integer.parseInt(m.group("wave")) : 12;
+		int wave = Integer.parseInt(m.group("wave"));
 		int duration = parseTimeString(m.group("duration"));
 		int cumulative = getCumulativeDuration();
 		int cumulativeWave = getCumulativeWaveDuration();

--- a/src/test/java/com/duckblade/osrs/fortis/features/timetracking/SplitsTrackerTest.java
+++ b/src/test/java/com/duckblade/osrs/fortis/features/timetracking/SplitsTrackerTest.java
@@ -36,7 +36,7 @@ public class SplitsTrackerTest
 		splitsTracker.onChatMessage(buildChatMessage("Wave 9 completed! Wave duration: 1:57.00"));
 		splitsTracker.onChatMessage(buildChatMessage("Wave 10 completed! Wave duration: 3:21.00"));
 		splitsTracker.onChatMessage(buildChatMessage("Wave 11 completed! Wave duration: 4:07.80"));
-		splitsTracker.onChatMessage(buildChatMessage("Colosseum duration: 29:42.60"));
+		splitsTracker.onChatMessage(buildChatMessage("Wave 12 completed! Wave duration: 29:42.60"));
 
 		List<Split> splits = splitsTracker.getSplits();
 		assertEquals(272, splits.get(11).getWaveDuration());
@@ -56,7 +56,7 @@ public class SplitsTrackerTest
 		splitsTracker.onChatMessage(buildChatMessage("Wave 9 completed! Wave duration: 1:57.00"));
 		splitsTracker.onChatMessage(buildChatMessage("Wave 10 completed! Wave duration: 3:21.00"));
 		splitsTracker.onChatMessage(buildChatMessage("Wave 11 completed! Wave duration: 4:07.80"));
-		splitsTracker.onChatMessage(buildChatMessage("Colosseum duration: 29:42.60"));
+		splitsTracker.onChatMessage(buildChatMessage("Wave 12 completed! Wave duration: 29:42.60"));
 
 		List<Split> splits = splitsTracker.getSplits();
 		assertEquals(53, splits.get(0).getCumulativeWaveDuration());


### PR DESCRIPTION
fixes #21

I tested it on 1 run. It worked correctly for the in game overlay as well as the txt file output.

overlay:

<img width="139" height="243" alt="image" src="https://github.com/user-attachments/assets/65617366-ee6e-4bdd-9d31-0f914400800f" />

txt file output: 
```
Wave 1: 0:24.00 / 0:24.00 / 0:24.00
Wave 2: 1:12.00 / 1:36.00 / 1:48.60
Wave 3: 0:54.00 / 2:30.00 / 2:57.60
Wave 4: 1:15.00 / 3:45.00 / 4:25.20
Wave 5: 1:56.40 / 5:41.40 / 6:35.40
Wave 6: 2:26.40 / 8:07.80 / 9:15.00
Wave 7: 1:46.80 / 9:54.60 / 11:12.00
Wave 8: 2:17.40 / 12:12.00 / 13:42.60
Wave 9: 1:53.40 / 14:05.40 / 15:46.80
Wave 10: 2:30.00 / 16:35.40 / 18:28.20
Wave 11: 2:37.80 / 19:13.20 / 21:17.40
Wave 12: 2:16.20 / 21:29.40 / 23:42.60

```
