### PR TITLE
CI: fix failing runs by upgrading Gradle wrapper validation to v3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Fixes CI failing in “Validate Gradle wrapper” by bumping to gradle/actions/wrapper-validation@v3