### PR TITLE
loot hider: fix hide wave 12 bug

### DIFF
--- a/src/main/java/com/duckblade/osrs/fortis/features/loot/LootHider.java
+++ b/src/main/java/com/duckblade/osrs/fortis/features/loot/LootHider.java
@@ -235,7 +235,7 @@ public class LootHider implements PluginLifecycleComponent
 	private boolean shouldHide(LootHiderMode mode)
 	{
 		return mode == LootHiderMode.ALWAYS ||
-			(mode == LootHiderMode.WAVE_12 && stateTracker.getCurrentState().getWaveNumber() != 12);
+			(mode == LootHiderMode.WAVE_12 && stateTracker.getCurrentState().getWaveNumber() == 12);
 	}
 
 	private void runGameTickQueuedActions()


### PR DESCRIPTION
A recent change 524e42b67e666aba5b7d6dd297462ba40d0efa6a to loot hider inverted the hide wave 12 logic.
This is a simple fix, hope you don't mind :)